### PR TITLE
Fix MaInput change handler and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install
 npm run dev
 ```
 
-访问 `http://localhost:3000/` 查看组件展示页面，或者 `http://localhost:3000/demo.html` 查看原始演示。
+访问 `http://localhost:3001/` 查看组件展示页面，或者 `http://localhost:3001/demo.html` 查看原始演示。
 
 ### 构建
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest'
   },
+  testPathIgnorePatterns: ['\\.d\\.ts$'],
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
     '!src/**/*.d.ts',

--- a/src/components/ma-input/__tests__/ma-input.test.ts
+++ b/src/components/ma-input/__tests__/ma-input.test.ts
@@ -205,6 +205,31 @@ describe('MaInput', () => {
       }).not.toThrow();
     });
 
+    it('setValue 应该触发 ma-change 事件并提供正确的上下文', async () => {
+      const validateResult = { valid: true, errors: [] };
+      const element: any = Object.create(MaInput.prototype);
+      element._input = document.createElement('input');
+      element._input.value = 'new value';
+      element._previousValue = 'old value';
+      element._validationRules = {};
+      element._lastValidationResult = validateResult;
+      element._validateValue = jest.fn().mockResolvedValue(validateResult);
+      element.dispatchEvent = jest.fn();
+      element.setAttribute = jest.fn();
+      element._updateComponent = jest.fn();
+
+      await element._handleChange(new Event('change'));
+
+      expect(element._validateValue).toHaveBeenCalledWith('new value');
+      expect(element.dispatchEvent).toHaveBeenCalledTimes(1);
+
+      const dispatchedEvent = element.dispatchEvent.mock.calls[0][0] as CustomEvent;
+      expect(dispatchedEvent.detail.value).toBe('new value');
+      expect(dispatchedEvent.detail.context.previousValue).toBe('old value');
+      expect(dispatchedEvent.detail.context.isUserInput).toBe(false);
+      expect(dispatchedEvent.detail.context.validationResult).toBe(validateResult);
+    });
+
     it('应该能添加到DOM而不抛出错误', () => {
       const newInput = document.createElement('ma-input') as MaInput;
       

--- a/src/components/ma-input/ma-input.ts
+++ b/src/components/ma-input/ma-input.ts
@@ -191,15 +191,16 @@ class MaInput extends HTMLElement {
   }
 
   private async _handleChange(event: Event): Promise<void> {
-    const value = (event.target as HTMLInputElement).value;
+    const target = event.target as HTMLInputElement | null;
+    const value = target?.value ?? this._input.value;
     const previousValue = this._previousValue;
-    
+
     const validationResult = await this._validateValue(value);
-    
+
     const context: InputChangeContext = {
       value,
       previousValue,
-      isUserInput: true,
+      isUserInput: event instanceof Event ? event.isTrusted : false,
       validationResult
     };
     

--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -154,7 +154,7 @@ describe('工具函数测试', () => {
 
   describe('injectStyles', () => {
     beforeEach(() => {
-      // 清理之前的style元素
+      // 清理之前的 style 元素
       document.head.innerHTML = '';
     });
 
@@ -167,7 +167,7 @@ describe('工具函数测试', () => {
       expect(styleElement?.textContent).toBe(styles);
     });
 
-    it('应该支持带ID的样式注入', () => {
+    it('应该支持带 ID 的样式注入', () => {
       const styles = '.test { color: blue; }';
       const id = 'test-styles';
       


### PR DESCRIPTION
## Summary
- handle change events without a DOM target in the MaInput component and respect trusted events when building context
- add coverage for the ma-change dispatch logic while ignoring stray declaration files and fixing a typo in the injectStyles tests
- document the correct webpack dev server port in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d627c532e083318110106532db1ce2