### PR TITLE
Fix lint errors in utilities and tests for CI

### DIFF
--- a/src/components/ma-button/ma-button.ts
+++ b/src/components/ma-button/ma-button.ts
@@ -1,6 +1,10 @@
-import { ButtonSize, ButtonVariant } from '@/types';
+import { ButtonSize, ButtonType, ButtonVariant } from '@/types';
 import { classNames, generateId } from '@/utils';
 import buttonStyles from './ma-button.scss';
+
+const isButtonType = (value: string | null): value is ButtonType => (
+  value === 'button' || value === 'submit' || value === 'reset'
+);
 
 // 按钮组件类
 class MaButton extends HTMLElement {
@@ -77,13 +81,14 @@ class MaButton extends HTMLElement {
   private _updateButton(): void {
     const size = this.getAttribute('size') as ButtonSize || 'medium';
     const variant = this.getAttribute('variant') as ButtonVariant || 'primary';
-    const type = this.getAttribute('type') || 'button';
+    const typeAttribute = this.getAttribute('type');
+    const buttonType: ButtonType = isButtonType(typeAttribute) ? typeAttribute : 'button';
     const disabled = this.hasAttribute('disabled');
     const loading = this.hasAttribute('loading');
     const customClass = this.getAttribute('class') || '';
 
     // 更新按钮属性
-    this._button.type = type as any;
+    this._button.type = buttonType;
     this._button.disabled = disabled || loading;
     
     // 更新按钮类名

--- a/src/components/ma-input/__tests__/ma-input.test.ts
+++ b/src/components/ma-input/__tests__/ma-input.test.ts
@@ -1,3 +1,4 @@
+import type { InputValidationRule, ValidationResult } from '@/types';
 import MaInput from '../ma-input';
 
 // 模拟CSS模块
@@ -206,15 +207,27 @@ describe('MaInput', () => {
     });
 
     it('setValue 应该触发 ma-change 事件并提供正确的上下文', async () => {
-      const validateResult = { valid: true, errors: [] };
-      const element: any = Object.create(MaInput.prototype);
+      type MaInputTestInstance = {
+        _handleChange: (event: Event) => Promise<void>;
+        _input: HTMLInputElement;
+        _previousValue: string;
+        _validationRules: InputValidationRule;
+        _lastValidationResult: ValidationResult;
+        _validateValue: jest.Mock<Promise<ValidationResult>, [string]>;
+        dispatchEvent: jest.Mock<boolean, [Event]>;
+        setAttribute: jest.Mock<void, [string, string]>;
+        _updateComponent: jest.Mock<void, []>;
+      };
+
+      const validateResult: ValidationResult = { valid: true, errors: [] };
+      const element = Object.create(MaInput.prototype) as MaInputTestInstance;
       element._input = document.createElement('input');
       element._input.value = 'new value';
       element._previousValue = 'old value';
       element._validationRules = {};
       element._lastValidationResult = validateResult;
       element._validateValue = jest.fn().mockResolvedValue(validateResult);
-      element.dispatchEvent = jest.fn();
+      element.dispatchEvent = jest.fn(() => true);
       element.setAttribute = jest.fn();
       element._updateComponent = jest.fn();
 

--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -44,7 +44,17 @@ describe('工具函数测试', () => {
 
   describe('deepMerge', () => {
     it('应该深度合并对象', () => {
-      const target = {
+      type Target = {
+        a: number;
+        b: {
+          c: number;
+          d: number;
+          e?: number;
+        };
+        f?: number;
+      };
+
+      const target: Target = {
         a: 1,
         b: {
           c: 2,
@@ -52,17 +62,17 @@ describe('工具函数测试', () => {
         }
       };
 
-      const source = {
+      const source: Partial<Target> = {
         b: {
           c: 2, // 保持原有的 c 属性
           d: 4,
           e: 5
         },
         f: 6
-      } as any;
+      };
 
       const result = deepMerge(target, source);
-      
+
       expect(result).toEqual({
         a: 1,
         b: {
@@ -75,11 +85,19 @@ describe('工具函数测试', () => {
     });
 
     it('不应该修改原对象', () => {
-      const target = { a: 1, b: { c: 2 } };
-      const source = { b: { c: 2, d: 3 } } as any;
-      
+      type Target = {
+        a: number;
+        b: {
+          c: number;
+          d?: number;
+        };
+      };
+
+      const target: Target = { a: 1, b: { c: 2 } };
+      const source: Partial<Target> = { b: { c: 2, d: 3 } };
+
       deepMerge(target, source);
-      
+
       expect(target).toEqual({ a: 1, b: { c: 2 } });
     });
   });

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -1,8 +1,8 @@
 export declare function generateId(prefix?: string): string;
 export declare function classNames(...classes: (string | undefined | null)[]): string;
-export declare function deepMerge<T>(target: T, source: Partial<T>): T;
-export declare function debounce<T extends (...args: any[]) => any>(func: T, wait: number): (...args: Parameters<T>) => void;
-export declare function throttle<T extends (...args: any[]) => any>(func: T, limit: number): (...args: Parameters<T>) => void;
+export declare function deepMerge<T extends Record<string, unknown>>(target: T, source: Partial<T>): T;
+export declare function debounce<T extends (...args: unknown[]) => unknown>(func: T, wait: number): (this: ThisParameterType<T>, ...args: Parameters<T>) => void;
+export declare function throttle<T extends (...args: unknown[]) => unknown>(func: T, limit: number): (this: ThisParameterType<T>, ...args: Parameters<T>) => void;
 export declare function supportsWebComponents(): boolean;
 export declare function injectStyles(styles: string, id?: string): void;
 //# sourceMappingURL=index.d.ts.map


### PR DESCRIPTION
## Summary
- ensure `ma-button` validates native button types instead of casting to `any`
- rework utility helpers to eliminate `any` usage and strengthen type declarations with updated tests
- tighten the MaInput unit test mocks with explicit typings for internal helpers

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63fe017dc83318a11e140bb0cd4a4