### PR TITLE
Add GitHub Pages workflow and exclude tests from builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build demo site
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "**/__tests__/*",
+    "**/*.test.ts",
+    "**/*.test.tsx"
   ]
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -37,7 +37,7 @@ const config = (_env: any, argv: { mode: string }): Configuration => {
         {
           test: /\.tsx?$/,
           use: 'ts-loader',
-          exclude: /node_modules/
+          exclude: [/node_modules/, /__tests__/]
         },
         {
           test: /\.s[ac]ss$/i,


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the project and deploys the demo to GitHub Pages
- update TypeScript and webpack settings so test files are excluded from production builds, preventing type errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d6426b4b148331a62183b6558fa14b